### PR TITLE
Modify setting of property DummyClass.Inherits

### DIFF
--- a/toolchain/interop.ts
+++ b/toolchain/interop.ts
@@ -16,10 +16,12 @@ export const closureToJS = (value: Value, context: Context, klass: string) => {
   Object.defineProperty(DummyClass, 'name', {
     value: klass
   })
-  DummyClass.Inherits = function(Parent: Value) {
-    DummyClass.prototype = Object.create(Parent.prototype)
-    DummyClass.prototype.constructor = DummyClass
-  }
+  Object.defineProperty(DummyClass, 'Inherits', {
+    value: (Parent: Value) => {
+        DummyClass.prototype = Object.create(Parent.prototype)
+        DummyClass.prototype.constructor = DummyClass
+    }
+  })
   DummyClass.call = function(thisArg: Value, ...args: Value[]) {
     return DummyClass.apply(thisArg, args)
   }


### PR DESCRIPTION
This replaces the typical property setting syntax (A.property) with Object.defineProperty(), which was used just the line before. As we are setting (or perhaps replacing) a property, this should not have any effect on the result.

This solves the initial error of setting a property that does not exist. #2 